### PR TITLE
tiledb-py 0.32.5 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/tiledb-feedstock/pr6/64b8fc4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/tiledb-feedstock/pr6/64b8fc4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ build:
 
 requirements:
   build:
-    - pybind11
     - cmake >=3.15
     - make
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - pybind11
     - cmake >=3.15
+    - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - pybind11
     - cmake >=3.15
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - pip
@@ -44,18 +45,20 @@ test:
     - pytest
     - pandas
     - psutil
+    - pip
   imports:
     - tiledb
   source_files:
     - tiledb/tests/
   commands:
+    - pip check
     - python -c "import tiledb; tiledb.libtiledb.version()"
     - python -c "import tiledb; assert not tiledb.VFS().supports('s3')" # we don't support s3
     - pytest -v --ignore-glob='*_examples.py' --ignore-glob='*_dask.py'
 {% endif %}
 
 about:
-  home: http://tiledb.io
+  home: https://tiledb.io
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -66,7 +69,7 @@ about:
     a novel on-disk format that can store dense and sparse array data with
     support for fast reads and updates and reads. It features excellent compression, and an efficient
     parallel I/O system with high scalability.
-  doc_url: https://api-reference.tiledb.io/python-api.html
+  doc_url: https://tiledb-inc-tiledb.readthedocs-hosted.com/projects/tiledb-py/en/stable/python-api.html
   dev_url: https://github.com/TileDB-Inc/TileDB-Py
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ test:
     - pandas
     - psutil
     - pip
+    - dask
   imports:
     - tiledb
   source_files:
@@ -57,7 +58,7 @@ test:
     - python -c "import tiledb; tiledb.libtiledb.version()"
     - python -c "import tiledb; assert not tiledb.VFS().supports('s3')" # we don't support backends in this build
     # test_multi_index_two_way_query - fleaky test
-    - pytest -v --ignore-glob='*_examples.py' --ignore-glob='*_dask.py' -k 'not test_multi_index_two_way_query'
+    - pytest -v --ignore-glob='*_examples.py' -k 'not test_multi_index_two_way_query'
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,10 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<39]
+  # Windows skip is due to snowflake only build of tiledb 2.26.2
+  skip: True  # [py<39 or s390x or win]
   ignore_run_exports:
     - numpy
-  missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:
@@ -56,7 +55,7 @@ test:
   commands:
     - pip check
     - python -c "import tiledb; tiledb.libtiledb.version()"
-    - python -c "import tiledb; assert not tiledb.VFS().supports('s3')" # we don't support s3
+    - python -c "import tiledb; assert not tiledb.VFS().supports('s3')" # we don't support backends in this build
     - pytest -v --ignore-glob='*_examples.py' --ignore-glob='*_dask.py'
 {% endif %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: faa507115731742e4eb0fbfec7be41310efcc46523afc188440b2d26ed48d361
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
   skip: True  # [py<39]
   ignore_run_exports:
     - numpy
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,8 @@ test:
     - pip check
     - python -c "import tiledb; tiledb.libtiledb.version()"
     - python -c "import tiledb; assert not tiledb.VFS().supports('s3')" # we don't support backends in this build
-    - pytest -v --ignore-glob='*_examples.py' --ignore-glob='*_dask.py'
+    # test_multi_index_two_way_query - fleaky test
+    - pytest -v --ignore-glob='*_examples.py' --ignore-glob='*_dask.py' -k 'not test_multi_index_two_way_query'
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
   run:
     - python
     - packaging
+    - numpy >=1.25
 
 {% if python_impl != 'pypy' %}
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "tiledb" %}
-{% set version = "0.32.2" %}
-{% set sha256 = "359599ecab0e46b5c8f8ad9ca8eef635ab2c94eb9dcf40767c4fef793b1810f4" %}
+{% set version = "0.32.5" %}
 
 package:
   name: tiledb-py
@@ -9,32 +8,30 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: faa507115731742e4eb0fbfec7be41310efcc46523afc188440b2d26ed48d361
 
 build:
   number: 0
+  skip: True  # [py<39]
+  ignore_run_exports:
+    - numpy
+
 requirements:
   build:
+    - pybind11
+    - cmake >=3.15
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython >=3.0                            # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
-    - pybind11                               # [build_platform != target_platform]
-    - cmake
-    - make
   host:
     - pip
     - wheel
     - setuptools
-    - setuptools_scm
+    - setuptools-scm
     - scikit-build-core
     - python
-    - cython >=3.0
-    - numpy
+    - cython >=3
+    - numpy >=2.0.1
     - pybind11
-    - tiledb >=2.26.0,<2.27
+    - tiledb >=2.26
   run:
     - python
     - packaging
@@ -53,7 +50,7 @@ test:
     - tiledb/tests/
   commands:
     - python -c "import tiledb; tiledb.libtiledb.version()"
-    - python -c "import tiledb; assert tiledb.VFS().supports('s3')"
+    - python -c "import tiledb; assert not tiledb.VFS().supports('s3')" # we don't support s3
     - pytest -v --ignore-glob='*_examples.py' --ignore-glob='*_dask.py'
 {% endif %}
 


### PR DESCRIPTION
tiledb-py 0.32.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5215]
- dev_url:        https://github.com/TileDB-Inc/TileDB-Py/tree/0.31.1
- conda_forge:    https://github.com/conda-forge/tiledb-py-feedstock
- pypi:           https://pypi.org/project/tiledb/0.31.1
- pypi inspector: https://inspector.pypi.io/project/tiledb/0.31.1

### Explanation of changes:

- new version number
- SNOWFLAKE ONLY build with no backends in tiledb


[PKG-5215]: https://anaconda.atlassian.net/browse/PKG-5215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ